### PR TITLE
Do not send callback additional parameters to yandex

### DIFF
--- a/lib/omniauth/strategies/yandex.rb
+++ b/lib/omniauth/strategies/yandex.rb
@@ -34,7 +34,7 @@ module OmniAuth
         if options.authorize_options.respond_to? :callback_url
           options.authorize_options.callback_url
         else
-          super
+          full_host + script_name + callback_path
         end
       end
 


### PR DESCRIPTION
We need push some additional parameters to callback. For example, site_id. To do this, we passing parameters to auth url
```
/auth/yandex?site_id=123
```
Base omniauth strategy save parameters in session and add it to callback url. In that case yandex response "400 redirect_uri не совпадает с Callback URL, указанным при регистрации приложения". Since the callback parameters can be taken from the session, there is no need to transfer them to Yandex.
