### PR TITLE
Add first_name and last_name to info

### DIFF
--- a/lib/omniauth/strategies/yandex.rb
+++ b/lib/omniauth/strategies/yandex.rb
@@ -26,7 +26,9 @@ module OmniAuth
         prune!({
           'nickname' => raw_info['display_name'],
           'email'  => raw_info['default_email'],
-          'name' => raw_info['real_name']
+          'name' => raw_info['real_name'],
+          'first_name' => raw_info['first_name'],
+          'last_name' => raw_info['last_name']
         })
       end
 


### PR DESCRIPTION
All omniauth strategies return first_name and last_name. It would be nice if this strategy also returned these parameters.